### PR TITLE
Replacement for cache helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "pry"
+gem "pry-byebug"
 
 if ENV["TRAVIS"]
   gem "coveralls", require: false

--- a/lib/cache_rocket/fragment.rb
+++ b/lib/cache_rocket/fragment.rb
@@ -20,6 +20,7 @@ module CacheRocket
       else
         replace_from_hash hash
       end
+      self
     end
 
     private

--- a/test/cache_rocket_test.rb
+++ b/test/cache_rocket_test.rb
@@ -3,6 +3,13 @@ require "test_helper"
 class CacheRocketTest < MiniTest::Spec
   class FakeRenderer
     include CacheRocket
+
+    attr_accessor :html
+
+    def safe_concat(value)
+      @html ||= ""
+      @html += value
+    end
   end
 
   def dog_name(dog)
@@ -121,6 +128,28 @@ class CacheRocketTest < MiniTest::Spec
       assert_raises(ArgumentError) do
         @renderer.render_cached("container")
       end
+    end
+  end
+
+  describe "#cache_replace" do
+    it "raise if missing replace option" do
+      assert_raises(ArgumentError) do
+        @renderer.cache_replace("x")
+      end
+    end
+
+    it "replaces key in content" do
+      @renderer.stubs :cache_fragment_name
+      @renderer.stubs fragment_for: "Hello <crk xyz>."
+      assert_nil @renderer.cache_replace("abc", replace: { xyz: "there" }) {}
+      assert_equal "Hello there.", @renderer.html
+    end
+
+    it "replaces keys in content" do
+      @renderer.stubs :cache_fragment_name
+      @renderer.stubs fragment_for: "Hello <crk xx>. <crk yy>."
+      assert_nil @renderer.cache_replace([0], replace: { xx: "1", yy: "2" }) {}
+      assert_equal "Hello 1. 2.", @renderer.html
     end
   end
 end

--- a/test/fragment_test.rb
+++ b/test/fragment_test.rb
@@ -32,7 +32,7 @@ module CacheRocket
         cr_key = Fragment.new(nil).cache_replace_key(:something)
         fragment = Fragment.new("hey #{cr_key} hey.")
         assert_equal "hey Tiger hey.hey Skunk hey.",
-          fragment.replace(replace_hash, collection)
+          fragment.replace(replace_hash, collection).to_s
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,6 @@ require "mocha/mini_test"
 require "cache_rocket"
 
 begin
-  require "pry"
+  require "pry-byebug"
 rescue LoadError
 end


### PR DESCRIPTION
From @strzibny :

Hi, cache rocket is a great idea. What I miss it to use it as a replacement for `cache` and `if_cache` helpers, e.g. together with some cache key (so cache and expire + always `sub` the uncacheable part). What do you think?