### PR TITLE
Dupe initialized fragment value

### DIFF
--- a/lib/cache_rocket/fragment.rb
+++ b/lib/cache_rocket/fragment.rb
@@ -5,7 +5,7 @@ module CacheRocket
     include Key
 
     def initialize(value)
-      @value = value
+      @value = value.to_s.dup
     end
 
     def to_s

--- a/test/fragment_test.rb
+++ b/test/fragment_test.rb
@@ -34,6 +34,12 @@ module CacheRocket
         assert_equal "hey Tiger hey.hey Skunk hey.",
           fragment.replace(replace_hash, collection).to_s
       end
+
+      it "does not modify initialized value" do
+        value = "Hi #{Fragment.new(nil).cache_replace_key(:x)}"
+        assert_equal "Hi 1", Fragment.new(value).replace({ x: "1"}, nil).to_s
+        assert_equal "Hi 2", Fragment.new(value).replace({ x: "2"}, nil).to_s
+      end
     end
   end
 end


### PR DESCRIPTION
Fix multiple calls with the same fragment string object